### PR TITLE
Short ammeters in LVS netlist

### DIFF
--- a/xschem/comparator_final.sch
+++ b/xschem/comparator_final.sch
@@ -844,7 +844,7 @@ sa=0 sb=0 sd=0
 model=nfet_g5v0d10v5
 spiceprefix=X
 }
-C {ammeter.sym} -190 -760 1 1 {name=Vbn180n savecurrent=true spice_ignore=0}
+C {ammeter.sym} -190 -760 1 1 {name=Vbn180n savecurrent=true spice_ignore=0 lvs_ignore=short}
 C {opin.sym} -40 -760 0 0 {name=p8 lab=ibn180n}
 C {sky130_fd_pr/nfet_01v8.sym} 360 -430 0 0 {name=M22
 L=1

--- a/xschem/delayPulse_final.sch
+++ b/xschem/delayPulse_final.sch
@@ -1843,5 +1843,5 @@ C {sky130_stdcells/inv_16.sym} 2320 90 0 0 {name=x10 VGND=VSS VNB=VSS VPB=VCCH V
 C {sky130_stdcells/inv_16.sym} 2320 140 0 0 {name=x8 VGND=VSS VNB=VSS VPB=VCCH VPWR=VCCH prefix=sky130_fd_sc_hvl__ }
 C {devices/lab_pin.sym} 1250 40 0 1 {name=p63 sig_type=std_logic lab=VCCL}
 C {devices/lab_pin.sym} 980 40 0 1 {name=p64 sig_type=std_logic lab=VCCL}
-C {ammeter.sym} 30 -1000 0 0 {name=Vvgbias savecurrent=true spice_ignore=0}
+C {ammeter.sym} 30 -1000 0 0 {name=Vvgbias savecurrent=true spice_ignore=0 lvs_ignore=short}
 C {ipin.sym} -70 -970 0 0 {name=p65 lab=ibn180n}

--- a/xschem/sky130_sw_ip__por.sch
+++ b/xschem/sky130_sw_ip__por.sch
@@ -149,9 +149,9 @@ C {devices/lab_wire.sym} 750 -430 0 0 {name=p18 lab=dvss}
 C {devices/lab_wire.sym} 280 -400 0 0 {name=p19 lab=avss}
 C {devices/lab_wire.sym} 320 -930 0 1 {name=p22 lab=avss}
 C {devices/lab_pin.sym} 290 -770 0 1 {name=p6 sig_type=std_logic lab=Vproc}
-C {devices/ammeter.sym} 290 -710 0 0 {name=Vrbranch savecurrent=true lvs_short=true}
-C {devices/ammeter.sym} 460 -460 3 0 {name=Vcomp savecurrent=true lvs_short=true}
-C {devices/ammeter.sym} 690 -390 3 0 {name=Vpulse savecurrent=true lvs_short=true}
+C {devices/ammeter.sym} 290 -710 0 0 {name=Vrbranch savecurrent=true lvs_ignore=short}
+C {devices/ammeter.sym} 460 -460 3 0 {name=Vcomp savecurrent=true lvs_ignore=short}
+C {devices/ammeter.sym} 690 -390 3 0 {name=Vpulse savecurrent=true lvs_ignore=short}
 C {sky130_fd_pr/nfet_05v0_nvt.sym} 270 -820 0 0 {name=M1
 L=0.9
 W=1


### PR DESCRIPTION
@RTimothyEdwards Added or corrected the settings to ignore ammeters in LVS netlists.